### PR TITLE
Add dependabot yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: 'bundler'
+    directory: '/'
+    schedule:
+      interval: 'daily'
+  open-pull-requests-limit: 5


### PR DESCRIPTION
This adds the configurations needed to enable dependabot for platform-console