### PR TITLE
Add permissions to code checks workflow

### DIFF
--- a/.github/workflows/code_checks.yml
+++ b/.github/workflows/code_checks.yml
@@ -1,5 +1,8 @@
 name: Code Checks
 on: [push]
+permissions:
+  contents: read
+  checks: write
 jobs:
   linting_and_security:
     name: Linting and Security


### PR DESCRIPTION
Add permissions to code checks so Dependabot runs can read secrets. [Changelog](https://github.blog/changelog/2021-10-06-github-actions-workflows-triggered-by-dependabot-prs-will-respect-permissions-key-in-workflows/)