### PR TITLE
Add git sha to ECR image

### DIFF
--- a/.github/workflows/push-images.yml
+++ b/.github/workflows/push-images.yml
@@ -3,7 +3,7 @@ name: Push image to ECR when changes are pushed to master
 on:
  push:
    branches:
-     - master
+     - lhattamer-test-git-sha
  workflow_dispatch:
 
 jobs:
@@ -41,5 +41,5 @@ jobs:
           account_id: '008577686731'
           repo: dsva/platform-console
           region: us-gov-west-1
-          tags: "${{ matrix.versions['name']}}-${{ matrix.versions['version'] }}"
+          tags: "${{ matrix.versions['name']}}-${{ matrix.versions['version'] }}-${{ github.sha }}"
           dockerfile: Dockerfile

--- a/.github/workflows/push-images.yml
+++ b/.github/workflows/push-images.yml
@@ -3,7 +3,7 @@ name: Push image to ECR when changes are pushed to master
 on:
  push:
    branches:
-     - lhattamer-test-git-sha
+     - master
  workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
This adds the git sha of the commit (latest master) to the docker image tag for ECR. This allows for the image to be unique and identifiable. I tested the timage tagging on this branch and it was successful. 