### PR TITLE
Comment out force_ssl

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -48,7 +48,7 @@ Rails.application.configure do
   # config.action_cable.allowed_request_origins = [ "http://example.com", /http:\/\/example.*/ ]
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  config.force_ssl = true
+  # config.force_ssl = true
 
   # Include generic and useful information about system operation, but avoid logging too much
   # information to avoid inadvertent exposure of personally identifiable information (PII).

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,6 +22,20 @@ This will:
 
 This has been tested on macOS Monterey using Ruby 3.1 and PG 14.1.
 
+## Semantic Releases
+This repository uses semantic releases triggered via Github Actions. When committing to the master branch, a semantic release vill be triggered via Github Actions, but the commit message must follow the syntax in the [semantic release documentation](https://github.com/semantic-release/semantic-release#how-does-it-work).
+
+#### Examples:
+```
+1. feat: add my feature
+2. fix: fix the bug
+3. BREAKING CHANGE: fix the breaking change
+4. perf: remove some change
+
+
+
+```
+
 ## Running tests
 
 To run all tests, run:

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,20 +22,6 @@ This will:
 
 This has been tested on macOS Monterey using Ruby 3.1 and PG 14.1.
 
-## Semantic Releases
-This repository uses semantic releases triggered via Github Actions. When committing to the master branch, a semantic release vill be triggered via Github Actions, but the commit message must follow the syntax in the [semantic release documentation](https://github.com/semantic-release/semantic-release#how-does-it-work).
-
-#### Examples:
-```
-1. feat: add my feature
-2. fix: fix the bug
-3. BREAKING CHANGE: fix the breaking change
-4. perf: remove some change
-
-
-
-```
-
 ## Running tests
 
 To run all tests, run:


### PR DESCRIPTION
While trying to deploy platform-console-api to the utility cluster, we ran into a redirect issue. We believe it's related to the force_ssl true configuration. vets-api also has this configuration commented out because SSL is terminated at the revproxy level and we don't force ssl for other socks only tooling.