### PR TITLE
Remove notion of versions.json

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -66,12 +66,6 @@ jobs:
           sudo add-apt-repository ppa:rmescandon/yq
           sudo apt update
           sudo apt install yq -y
-      - name: Set component versions as environment variables
-        run: |
-          for COMPONENT in $(cat versions.json | jq -r '.components | .[] | .name + "=" + (.version)')
-          do
-            echo "$COMPONENT" >> $GITHUB_ENV
-          done
       - name: Check out Manifest Repo
         uses: actions/checkout@v2
         with:
@@ -90,7 +84,7 @@ jobs:
           envs=( ${{ needs.prepare-values.outputs.environments }} )
           for env in ${envs[*]};
           do
-            yq e -i '.spec.template.spec.containers.[0].image = "008577686731.dkr.ecr.us-gov-west-1.amazonaws.com/dsva/platform-console:ruby-${{ env.ruby }}-${{ github.sha }}"' $env/deployment.yml
+            yq e -i '.spec.template.spec.containers.[0].image = "008577686731.dkr.ecr.us-gov-west-1.amazonaws.com/dsva/platform-console:platform-console-${{ github.sha }}"' $env/deployment.yml
           done
           git diff
       - name: Add and Commit file

--- a/.github/workflows/push-images.yml
+++ b/.github/workflows/push-images.yml
@@ -7,30 +7,9 @@ on:
  workflow_dispatch:
 
 jobs:
-  prepare-build:
-    name: Prepare build for image push to ECR
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/checkout@v2
-      - name: Capture argo image versions
-        id: componentVersions
-        run: |
-          echo "::set-output name=config::$(jq -c .components versions.json)"
-      - name: Upload versions file
-        uses: actions/upload-artifact@v2
-        with:
-          name: versions
-          path: versions.json
-    outputs:
-      config: ${{ steps.componentVersions.outputs.config }}
-
   push-image:
     runs-on: ubuntu-20.04
     name: Push image to ECR
-    needs: prepare-build
-    strategy:
-      matrix:
-        versions: ${{ fromJson(needs.prepare-build.outputs.config) }}
     steps:
       - uses: actions/checkout@v2
       - name: Build and push argo images to ECR
@@ -41,6 +20,6 @@ jobs:
           account_id: '008577686731'
           repo: dsva/platform-console
           region: us-gov-west-1
-          tags: "${{ matrix.versions['name']}}-${{ matrix.versions['version'] }}-${{ github.sha }}"
+          tags: "platform-console-${{ github.sha }}"
           dockerfile: Dockerfile
           extra_build_args: "--build-arg RAILS_ENV=production"

--- a/versions.json
+++ b/versions.json
@@ -1,8 +1,0 @@
-{
-  "components": [
-    {
-      "name": "ruby",
-      "version": "3.1.0"
-    }
-  ]
-}


### PR DESCRIPTION
This PR removes the notion of a versions.json file. The versions pattern is something that was used for other apps that had dependencies and ruby isn't necessarily a dependency of platform-console, but rather a part of it's custom solution. Along with removing the versions.json, the deploy.yml and push-images.yml were cleaned up and updated.