### PR TITLE
Upgraded rubocop and changed  EnforcedShorthandSyntax default from al…

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,3 +5,6 @@ AllCops:
 
 Metrics/MethodLength:
   Max: 15
+
+Style/HashSyntax:
+  EnforcedShorthandSyntax: either

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -151,8 +151,6 @@ GEM
       racc (~> 1.4)
     nokogiri (1.13.1-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.13.1-x86_64-darwin)
-      racc (~> 1.4)
     nokogiri (1.13.1-x86_64-linux)
       racc (~> 1.4)
     pagy (5.10.1)
@@ -211,7 +209,7 @@ GEM
     redis (4.6.0)
     regexp_parser (2.2.0)
     rexml (3.2.5)
-    rubocop (1.25.0)
+    rubocop (1.25.1)
       parallel (~> 1.10)
       parser (>= 3.1.0.0)
       rainbow (>= 2.2.2, < 4.0)
@@ -235,7 +233,7 @@ GEM
       childprocess (>= 0.5, < 5.0)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2)
-    sidekiq (6.4.0)
+    sidekiq (6.4.1)
       connection_pool (>= 2.2.2)
       rack (~> 2.0)
       redis (>= 4.2.0)
@@ -261,8 +259,6 @@ GEM
       railties (>= 6.0.0)
     tailwindcss-rails (2.0.5-arm64-darwin)
       railties (>= 6.0.0)
-    tailwindcss-rails (2.0.5-x86_64-darwin)
-      railties (>= 6.0.0)
     tailwindcss-rails (2.0.5-x86_64-linux)
       railties (>= 6.0.0)
     thor (1.2.1)
@@ -282,12 +278,12 @@ GEM
     websocket-extensions (0.1.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    zeitwerk (2.5.3)
+    zeitwerk (2.5.4)
 
 PLATFORMS
+  arm64-darwin-20
   arm64-darwin-21
   ruby
-  x86_64-darwin
   x86_64-linux
 
 DEPENDENCIES


### PR DESCRIPTION
Rubocop, 1.25.1, has changed default syntax values to support Ruby 3.1's hash value shorthand syntax. 

<img width="701" alt="Screen Shot 2022-02-07 at 3 07 15 PM" src="https://user-images.githubusercontent.com/32692924/152871944-ceb024d4-bb72-48fc-8510-280e8597b056.png">

