### PR TITLE
Update ECR image name to be env var

### DIFF
--- a/.github/workflows/deploy-template.yml
+++ b/.github/workflows/deploy-template.yml
@@ -17,6 +17,8 @@ on:
         required: true
       aws_secret_access_key: #${{ secrets.AWS_SECRET_ACCESS_KEY }}
         required: true
+env:
+  IMAGE_NAME: "008577686731.dkr.ecr.us-gov-west-1.amazonaws.com/dsva/${{inputs.ecr_repository}}:${{inputs.ecr_repository}}-${{ github.sha }}"
 
 jobs:
   prepare-values:
@@ -84,11 +86,10 @@ jobs:
           ECR_REPOSITORY: dsva/${{inputs.ecr_repository}}
         run: |
           cd vsp-infra-application-manifests/apps/${{inputs.manifests_directory}}
-          image_name = "008577686731.dkr.ecr.us-gov-west-1.amazonaws.com/dsva/${{inputs.ecr_repository}}:${{inputs.ecr_repository}}-${{ github.sha }}"
           envs=( ${{ needs.prepare-values.outputs.environments }} )
           for env in ${envs[*]}; do
-            yq e -i '.spec.template.spec.containers.[0].image = ${image_name}' $env/deployment.yml
-            yq e -i '.spec.template.spec.initContainers.[0].image = ${image_name}' $env/deployment.yml
+            yq e -i '.spec.template.spec.containers.[0].image = ${IMAGE_NAME}' $env/deployment.yml
+            yq e -i '.spec.template.spec.initContainers.[0].image = ${IMAGE_NAME}' $env/deployment.yml
           done
 
       - name: Add and Commit file


### PR DESCRIPTION
Merging [this PR](https://github.com/department-of-veterans-affairs/platform-console-api/commit/4c0abf4089553cbadc8b155411bf59bcd8f9eac3) to master caused the update-manifests image tag piece in the PR to fail because the image_name var was undefined. It was decided to move this to an env var instead