### PR TITLE
Add workflow_dispatch to codeql.yml

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,6 +8,7 @@ on:
     branches: [ master ]
   schedule:
     - cron: '27 2 * * 1'
+  workflow_dispatch:
 
 jobs:
   analyze:


### PR DESCRIPTION
Add `workflow_dispatch` to codeql.yml in order to test the Github workflow dispatch integration