### PR TITLE
Update yml to use select

### DIFF
--- a/.github/workflows/deploy-template.yml
+++ b/.github/workflows/deploy-template.yml
@@ -12,6 +12,9 @@ on:
       auto_deploy_envs:
        required: true # utility
        type: string
+      app_name:
+       required: true # platform-console-api
+       type: string
     secrets:
       aws_access_key_id: #${{ secrets.AWS_ACCESS_KEY_ID }}
         required: true
@@ -87,8 +90,8 @@ jobs:
           envs=( ${{ needs.prepare-values.outputs.environments }} )
           for env in ${envs[*]};
           do
-            yq e -i '(.spec.template.spec.containers[] | select(.name == "platform-console-api").image) |= "008577686731.dkr.ecr.us-gov-west-1.amazonaws.com/dsva/${{inputs.ecr_repository}}:${{inputs.ecr_repository}}-${{ github.sha }}"' $env/deployment.yml
-            yq e -i '(.spec.template.spec.initContainers[] | select(.name == "platform-console-api").image) |= "008577686731.dkr.ecr.us-gov-west-1.amazonaws.com/dsva/${{inputs.ecr_repository}}:${{inputs.ecr_repository}}-${{ github.sha }}"' $env/deployment.yml
+            yq e -i '(.spec.template.spec.containers[] | select(.name == ${{inputs.app_name}}).image) |= "008577686731.dkr.ecr.us-gov-west-1.amazonaws.com/dsva/${{inputs.ecr_repository}}:${{inputs.ecr_repository}}-${{ github.sha }}"' $env/deployment.yml
+            yq e -i '(.spec.template.spec.initContainers[] | select(.name == ${{inputs.app_name}}).image) |= "008577686731.dkr.ecr.us-gov-west-1.amazonaws.com/dsva/${{inputs.ecr_repository}}:${{inputs.ecr_repository}}-${{ github.sha }}"' $env/deployment.yml
           done
 
       - name: Add and Commit file

--- a/.github/workflows/deploy-template.yml
+++ b/.github/workflows/deploy-template.yml
@@ -87,8 +87,8 @@ jobs:
           envs=( ${{ needs.prepare-values.outputs.environments }} )
           for env in ${envs[*]};
           do
-            yq e -i '.spec.template.spec.containers.[0].image = "008577686731.dkr.ecr.us-gov-west-1.amazonaws.com/dsva/${{inputs.ecr_repository}}:${{inputs.ecr_repository}}-${{ github.sha }}"' $env/deployment.yml
-            yq e -i '.spec.template.spec.initContainers.[0].image = "008577686731.dkr.ecr.us-gov-west-1.amazonaws.com/dsva/${{inputs.ecr_repository}}:${{inputs.ecr_repository}}-${{ github.sha }}"' $env/deployment.yml
+            yq e -i '(.spec.template.spec.containers[] | select(.name == "platform-console-api").image) |= "008577686731.dkr.ecr.us-gov-west-1.amazonaws.com/dsva/${{inputs.ecr_repository}}:${{inputs.ecr_repository}}-${{ github.sha }}"' $env/deployment.yml
+            yq e -i '(.spec.template.spec.initContainers[] | select(.name == "platform-console-api").image) |= "008577686731.dkr.ecr.us-gov-west-1.amazonaws.com/dsva/${{inputs.ecr_repository}}:${{inputs.ecr_repository}}-${{ github.sha }}"' $env/deployment.yml
           done
 
       - name: Add and Commit file

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,6 +13,7 @@ jobs:
       ecr_repository: 'platform-console'
       manifests_directory: 'vsp-tools-backend/platform-console-api'
       auto_deploy_envs: 'utility'
+      app_name: 'platform-console-api'
     secrets:
       aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
       aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
This PR updates the deploy-template workflow to use select (via yq) to update the image tag line. By using select instead of a fixed position [0], this gives more flexibility if the manifests yml file spec were to change it's ordering.