### PR TITLE
Add workflow_run to GHA workflows

### DIFF
--- a/.github/workflows/deploy-template.yml
+++ b/.github/workflows/deploy-template.yml
@@ -12,9 +12,6 @@ on:
       auto_deploy_envs:
        required: true # utility
        type: string
-      app_name:
-       required: true # platform-console-api
-       type: string
     secrets:
       aws_access_key_id: #${{ secrets.AWS_ACCESS_KEY_ID }}
         required: true
@@ -90,8 +87,8 @@ jobs:
           envs=( ${{ needs.prepare-values.outputs.environments }} )
           for env in ${envs[*]};
           do
-            yq e -i '(.spec.template.spec.containers[] | select(.name == ${{inputs.app_name}}).image) |= "008577686731.dkr.ecr.us-gov-west-1.amazonaws.com/dsva/${{inputs.ecr_repository}}:${{inputs.ecr_repository}}-${{ github.sha }}"' $env/deployment.yml
-            yq e -i '(.spec.template.spec.initContainers[] | select(.name == ${{inputs.app_name}}).image) |= "008577686731.dkr.ecr.us-gov-west-1.amazonaws.com/dsva/${{inputs.ecr_repository}}:${{inputs.ecr_repository}}-${{ github.sha }}"' $env/deployment.yml
+            yq e -i '.spec.template.spec.containers.[0].image = "008577686731.dkr.ecr.us-gov-west-1.amazonaws.com/dsva/${{inputs.ecr_repository}}:${{inputs.ecr_repository}}-${{ github.sha }}"' $env/deployment.yml
+            yq e -i '.spec.template.spec.initContainers.[0].image = "008577686731.dkr.ecr.us-gov-west-1.amazonaws.com/dsva/${{inputs.ecr_repository}}:${{inputs.ecr_repository}}-${{ github.sha }}"' $env/deployment.yml
           done
 
       - name: Add and Commit file

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - master
   workflow_dispatch:
+  workflow_run:
+    workflows: ["Push image to ECR when changes are pushed to master"]
+    types: [completed]
 
 jobs:
   deploy:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,7 +13,6 @@ jobs:
       ecr_repository: 'platform-console'
       manifests_directory: 'vsp-tools-backend/platform-console-api'
       auto_deploy_envs: 'utility'
-      app_name: 'platform-console-api'
     secrets:
       aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
       aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/push-images.yml
+++ b/.github/workflows/push-images.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - master
   workflow_dispatch:
+  workflow_run:
+    workflows: ["Code Checks"]
+    types: [completed]
 
 jobs:
   push-images:


### PR DESCRIPTION
This PR adds workflow_run specifications to the deploy and push image workflows. Currently, the manifests repo is getting updated with the image tag before the image is pushed to ECR. The changes here require the image to be pushed to ECR before updating the image tag in the manifests repo

Secondly, the image is being pushed to ECR before the code checks even run. The changes here require code checks to pass before pushing to ECR.