### PR TITLE
Added the ability to access user permissions and roles from Keycloak Permissions.

### DIFF
--- a/app/controllers/omniauth_controller.rb
+++ b/app/controllers/omniauth_controller.rb
@@ -17,12 +17,27 @@ class OmniauthController < SessionsController
   private
 
   def set_user
-    @user = User.from_omniauth(auth_hash)
+    @user = User.from_omniauth(auth_hash, keycloak_token_hash)
   end
 
   protected
 
   def auth_hash
     request.env['omniauth.auth']
+  end
+
+  def keycloak_token_hash
+    return nil if auth_hash['credentials'].blank?
+
+    conn = Faraday.new
+    response = conn.post(ENV['KEYCLOAK_TOKEN_URL']) do |req|
+      req.headers =
+        {
+          'Content-Type' => 'application/x-www-form-urlencoded',
+          'Authorization' => "Bearer #{auth_hash['credentials']['token']}"
+        }
+      req.body = 'grant_type=urn:ietf:params:oauth:grant-type:uma-ticket&audience=account'
+    end
+    JWT.decode(JSON.parse(response.body)['access_token'], nil, false)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,16 +9,20 @@ class User < ApplicationRecord
   validates :email, uniqueness: true
   validates :name, :email, presence: true
 
-  def self.from_omniauth(auth_hash)
+  def self.from_omniauth(auth_hash, _keycloak_hash)
     User.find_or_initialize_by(uid: auth_hash['uid']) do |u|
       u.name = auth_hash['info']['name']
       u.email = auth_hash['info']['email']
       u.password = SecureRandom.uuid
       u.save!
+      # teams = auth_hash['extra']['raw_info']['groups']
+      # teams.each do |team|
+      #   team = Team.find_or_create_by(name: team, owner: u, owner_type: "User")
+      # end
     end
-    # Authorize user and ensure keycloak is the provider
-    # teams = auth_hash['extra']['raw_info']['groups']
-    # roles = auth_hash['extra']['raw_info']['resource_access']['account']['roles']
+
+    # Use keycloak_hash for roles
+    # realm_roles = keycloak_hash['extra']['raw_info']['resource_access']['account']['roles']
   end
 
   private

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -2,10 +2,12 @@
 
 Rails.application.config.middleware.use OmniAuth::Builder do
   provider  :keycloak_openid, ENV['KEYCLOAK_CLIENT_ID'] || 'account', ENV['KEYCLOAK_CLIENT_SECRET'] || '',
-            scope: 'openid profile email',
-            client_options: { site: ENV['KEYCLOAK_SITE_URL'] || 'http://localhost:8080',
-                              realm: ENV['KEYCLOAK_REALM'] || 'Twilight' },
-            name: 'keycloak'
+            scope: 'openid profile email', redirect_uri: ENV['KEYCLOAK_REDIRECT_URI'],
+            client_options: { site: ENV['KEYCLOAK_SITE_URL'],
+                              realm: ENV['KEYCLOAK_REALM'] },
+
+            name: 'keycloak',
+            strategy_class: OmniAuth::Strategies::KeycloakOpenId
 end
 
 OmniAuth.config.allowed_request_methods = %i[post get]


### PR DESCRIPTION
The initial OAuth request to Keycloak is called the authorization request. In the authorization request, Keycloak returns user info and a OAuth token. OAuth requests do not contain a lot of user data and why it has gained popularity over SAML. To obtain permissions and authentication scopes from Keycloak there needs to be a request to Keycloak's token endpoint with the OAuth token included in the header request.  The response from the token request contains an access token. Keycloak authorization permissions, policies, and roles for the user can be accessed by decoding the access token.

This OAuth workflow demonstrates the authentication request and new token request.

<img width="780" alt="Screen Shot 2022-03-03 at 1 17 53 PM" src="https://user-images.githubusercontent.com/32692924/156637550-22644d55-0826-45ef-874b-dd8fc781bddc.png">



