### PR TITLE
Adding ddtrace gem to send APM to Datadog

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gem 'rails', '~> 7.0.2'
 
 gem 'bcrypt',            '~> 3.1' # Use ActiveModel has_secure_password
 gem 'bootsnap',          '~> 1.10', require: false # Reduces boot times through caching; required in config/boot.rb
+gem 'ddtrace',           '~> 0.54', require: 'ddtrace/auto_instrument' # Datadog's tracing client for Ruby
 gem 'flipper',           '~> 0.24' # Feature flipper for ANYTHING
 gem 'flipper-redis',     '~> 0.24' # Redis adapter for Flipper
 gem 'flipper-ui',        '~> 0.24' # UI for the Flipper gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,6 +94,10 @@ GEM
     concurrent-ruby (1.1.9)
     connection_pool (2.2.5)
     crass (1.0.6)
+    ddtrace (0.54.2)
+      debase-ruby_core_source (<= 0.10.14)
+      msgpack
+    debase-ruby_core_source (0.10.14)
     digest (3.1.0)
     docile (1.4.0)
     erubi (1.10.0)
@@ -353,6 +357,7 @@ DEPENDENCIES
   brakeman
   bundler-audit
   capybara
+  ddtrace (~> 0.54)
   flipper (~> 0.24)
   flipper-redis (~> 0.24)
   flipper-ui (~> 0.24)

--- a/config/initializers/datadog.rb
+++ b/config/initializers/datadog.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+Datadog.configure do |c|
+  c.use :rails
+  c.service = 'platform-console-api'
+  c.tracer.enabled = true
+  c.tracer hostname: 'datadog-agent',
+           port: 8126
+end


### PR DESCRIPTION
This PR adds the ddtrace gem and a datadog.rb initializer file for sending APM to Datadog.