### PR TITLE
Add rails master key env var

### DIFF
--- a/.github/workflows/push-image-template.yml
+++ b/.github/workflows/push-image-template.yml
@@ -15,6 +15,8 @@ on:
 
 jobs:
   push-image:
+    env:
+      RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
     runs-on: ubuntu-20.04
     name: Push image to ECR
     steps:


### PR DESCRIPTION
The push_images workflow is failing without the RAILS_MASTER_KEY env var `Missing encryption key to decrypt file with.` . This PR adds the necessary env var. The platform-console-api is currently broken since the image wasn't pushed and can't be found.