### PR TITLE
Test SSL 500 error 

### DIFF
--- a/lib/argo_cd/client.rb
+++ b/lib/argo_cd/client.rb
@@ -26,7 +26,7 @@ module ArgoCd
 
     def get_app_info(uri)
       https = Net::HTTP.new(uri.host, uri.port)
-      https.verify_mode = OpenSSL::SSL::VERIFY_NONE if Rails.env.development?
+      https.verify_mode = OpenSSL::SSL::VERIFY_NONE
       response = https.get(uri, request_headers)
 
       Response.new(response: response)
@@ -58,7 +58,7 @@ module ArgoCd
     def generate_token
       uri = URI("#{base_path}/api/v1/session")
       https = Net::HTTP.new(uri.host, uri.port)
-      https.verify_mode = OpenSSL::SSL::VERIFY_NONE if Rails.env.development?
+      https.verify_mode = OpenSSL::SSL::VERIFY_NONE
 
       request = build_request(uri)
 


### PR DESCRIPTION
The [Argo integration](https://github.com/department-of-veterans-affairs/platform-console-api/pull/149) was merged and is live, but when navigating the the show page (which makes an API call to Argo), a 500 error is returned. We _think_ that this might be related to the self signed cert. This change will not be permanent and just temporarily for testing purposes. 