### PR TITLE
Add 'fix:' prefix to dependabot commits for semantic releases

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,5 @@ updates:
     schedule:
       interval: 'daily'
     open-pull-requests-limit: 5
+    commit-message:
+      prefix: 'fix:'


### PR DESCRIPTION
Add `fix:` prefix for semantic releases