### PR TITLE
fix: update vcr to use latest version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,7 +51,7 @@ group :test do
   gem 'minitest-ci'        # Minitest Junit XML results for GHA
   gem 'selenium-webdriver' # Capybara system testing with Chrome
   gem 'simplecov'          # Code coverage for Ruby
-  gem 'vcr',               github: 'vcr/vcr' # Edge version for Ruby 3.1 support. Record/replay HTTP interactions
+  gem 'vcr'               # Record/replay HTTP interactions
   gem 'webdrivers'         # Easy installation and use of web drivers to run system tests with browsers
   gem 'webmock'            # Stubbing and setting expectations in HTTP requests
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,3 @@
-GIT
-  remote: https://github.com/vcr/vcr.git
-  revision: 7ac8292c289ca98dcb4254b59e1ee29e2205d8b3
-  specs:
-    vcr (6.0.0)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -351,6 +345,7 @@ GEM
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.1.0)
     uri (0.11.0)
+    vcr (6.1.0)
     webdrivers (5.0.0)
       nokogiri (~> 1.6)
       rubyzip (>= 1.3.0)
@@ -410,7 +405,7 @@ DEPENDENCIES
   strong_migrations (~> 1.0)
   tailwindcss-rails (~> 2.0)
   turbo-rails (~> 1.0)
-  vcr!
+  vcr
   webdrivers
   webmock
 


### PR DESCRIPTION
Update `vcr` to latest version. We were using master branch for ruby 3 support. This has been fixed in the latest release (6.1.0)