### PR TITLE
Hide Keycloak login if there is not a defined keycloak site.

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# Handles home page
 class PagesController < ApplicationController
   layout 'pages'
 end

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -19,11 +19,13 @@
           Log In
         </a>
       </div>
-      <div class="mt-6">
-        <a href='/auth/keycloak' class="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-black text-opacity-75 bg-white bg-opacity-75 sm:bg-opacity-25 sm:hover:bg-opacity-50">
-          Sign In Keycloak
-        </a>
-      </div>
+      <% if Flipper.enabled? :keycloak_login %>
+        <div class="mt-6">
+          <a href='/auth/keycloak' class="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-black text-opacity-75 bg-white bg-opacity-75 sm:bg-opacity-25 sm:hover:bg-opacity-50">
+            Sign In Keycloak
+          </a>
+        </div>
+      <% end %>
     <% end %>
   </div>
 </main>


### PR DESCRIPTION
Hide the Login via Keycloak link if there is not a Keycloak site defined. At the moment, there are no Keycloak instances running in production.