### PR TITLE
Update rack to 2.2.3.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -246,7 +246,7 @@ GEM
     puma (5.6.4)
       nio4r (~> 2.0)
     racc (1.6.0)
-    rack (2.2.3)
+    rack (2.2.3.1)
     rack-mini-profiler (3.0.0)
       rack (>= 1.2.0)
     rack-protection (2.2.0)


### PR DESCRIPTION
```
Name: rack
Version: 2.2.3
CVE: CVE-2022-30[12](https://github.com/department-of-veterans-affairs/platform-console-api/runs/6691402282?check_suite_focus=true#step:4:13)2
GHSA: GHSA-hxqx-xwvh-44m2
Criticality: Unknown
URL: https://groups.google.com/g/ruby-security-ann/c/L2Axto442qk
Title: Denial of Service Vulnerability in Rack Multipart Parsing
Solution: upgrade to '~> 2.0.9, >= 2.0.9.1', '~> 2.1.4, >= 2.1.4.1', '>= 2.2.3.1'
```