### PR TITLE
Initial cut of console-ui catalog entry

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -23,6 +23,26 @@ spec:
     servers:
       - url: http://platform-console-api.vfs.va.gov/
     paths:
-      /v1/teams:
+      '/v1/teams':
         get:
           summary: List of teams
+        responses:
+          '200':
+            description: Successfully returned teams 
+            schema:
+              type: object
+              required:
+              - data
+              properties:
+                data:
+                  type: object
+                  required:
+                  - teams
+                  properties:
+                    teams:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          name:
+                            type: string

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,28 @@
+apiVersion: backstage.io/v1alpha1
+kind: API
+metadata:
+  name: platform-console-api
+  description: API for creating and deploying applications on the VA Platform.
+  annotations:
+    github.com/project-slug: department-of-veterans-affairs/platform-console-api
+  tags:
+    - ruby
+    - rails
+    - platform-console-api
+spec:
+  type: openapi
+  lifecycle: production
+  owner: platform-console-services
+  definition: | 
+    openapi: "3.0.0"
+    info:
+      version: 1.0.0
+      title: Platform Console API
+      license:
+        name: MIT
+    servers:
+      - url: http://platform-console-api.vfs.va.gov/
+    paths:
+      /v1/teams:
+        get:
+          summary: List of teams


### PR DESCRIPTION
This is the catalog-info yaml file that is needed for console-ui.  For `kind: API`, it appears that the [spec.definition](https://backstage.io/docs/features/software-catalog/descriptor-format#specdefinition-required) is required, but we don't have an openapi doc solution at the moment.  We're working on some discovery around an openapi doc solution, it's just not fully fleshed out yet.  [Discovery ticket here](https://github.com/orgs/department-of-veterans-affairs/projects/547/views/17?filterQuery=open+ap). I added a placeholder path entry for the time being. Eventually the definition attribute will point to our completed openapi documentation. The console-ui team confirmed that a placeholder is ok for the time being.


Related thread in the pst-console-ui slack channel: https://dsva.slack.com/archives/C02QH29CQ3F/p1654790274231929


I used the [Descriptor Format doc ](https://backstage.io/docs/features/software-catalog/descriptor-format#kind-api)for the necessary attributes needed for `kind: API `


Related Ticket: https://github.com/department-of-veterans-affairs/va.gov-team/issues/41315