### PR TITLE
Add mkdocs.yml

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,12 @@
+site_name: 'Platform Console API'
+site_description: 'The Platform Console API: for creating and deploying applications on the VA Platform.'
+repo_url: https://github.com/department-of-veterans-affairs/platform-console-api
+edit_uri: edit/master/docs/
+
+nav:
+  - README: 'README.md'
+  - Licence: 'LICENSE.md'
+  - Security: 'SECURITY.md'
+
+plugins:
+  - techdocs-core


### PR DESCRIPTION
Per feedback from Console UI, a mkdocs.yml file was needed for the Console UI onboarding to import the techdocs correctly. [See comment here.](https://github.com/department-of-veterans-affairs/platform-pst-console-ui-configuration/issues/78#issuecomment-1169242138)